### PR TITLE
Fix init

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -36,7 +36,7 @@ Humanizer Portugues
 Features
 --------
 
-* This lib contains various humanization methods such as transforming a time difference in a human-readable duration 'três minutos atrás' (three minutes ago) or in a phrase.
+* This lib contains various humanization methods such as transforming a time difference in a human-readable duration "três minutos atrás" (three minutes ago) or in a phrase.
 
 
 Requirements
@@ -65,74 +65,52 @@ Import the lib with:
    import humanizer_portugues
 
 
-Humanization of dates and time:
-
-.. code-block:: python
-
-   import datetime
-   humanizer_portugues.natural_period(datetime.time(5, 30, 0).hour)
-   'manhã'
-
-   humanizer_portugues.natural_clock(datetime.time(0, 30, 0))
-   'zero hora e trinta minutos'
-
-   humanizer_portugues.natural_clock(datetime.time(0, 30, 0), formal=False)
-   'meia noite e meia'
-
-   humanizer_portugues.natural_day(datetime.datetime.now())
-   'hoje'
-
-   humanizer_portugues.natural_delta(datetime.timedelta(seconds=1001))
-   '16 minutos'
-
-   humanizer_portugues.natural_day(datetime.datetime.now() - datetime.timedelta(days=1))
-   'ontem'
-
-   humanizer_portugues.natural_day(datetime.date(2007, 6, 5))
-   '5 de junho'
-
-   humanizer_portugues.natural_date(datetime.date(2007, 6, 5))
-   '5 de junho de 2007'
-
-   humanizer_portugues.natural_time(datetime.datetime.now() - datetime.timedelta(seconds=1))
-   'há um segundo'
-
-   humanizer_portugues.natural_time(datetime.datetime.now() - datetime.timedelta(seconds=3600))
-   'há uma hora'
-
-
 Humanization filesizes:
 
 .. code-block:: python
 
    humanizer_portugues.natural_size(1000000)
-   '1.0 MB'
+   "1.0 MB"
 
    humanizer_portugues.natural_size(1000000, binary=True)
-   '976.6 KiB'
+   "976.6 KiB"
 
    humanizer_portugues.natural_size(1000000, gnu=True)
-   '976.6K'
+   "976.6K"
+
+
+Humanization of lists:
+
+.. code-block:: python
+
+   humanizer_portugues.natural_list(["Cláudio", "Maria"], ",")
+   "Cláudio, Maria"
+
+   humanizer_portugues.natural_list(["Cláudio", "Maria"], ",", "e")
+   "Cláudio e Maria"
+
+   humanizer_portugues.natural_list(["Cláudio", "Maria", "José"], ";", "ou")
+   "Cláudio; Maria ou José"
 
 
 Humanization of integers:
 
 .. code-block:: python
 
-   humanizer_portugues.int_comma(12345)
-   '12,345'
-
-   humanizer_portugues.int_word(123455913)
-   '123.5 milhão'
-
-   humanizer_portugues.int_word(12345591313)
-   '12.3 bilhão'
-
    humanizer_portugues.ap_number(4)
-   'quatro'
+   "quatro"
 
    humanizer_portugues.ap_number(41)
-   '41'
+   "41"
+
+   humanizer_portugues.int_comma(12345)
+   "12,345"
+
+   humanizer_portugues.int_word(123455913)
+   "123.5 milhão"
+
+   humanizer_portugues.int_word(12345591313)
+   "12.3 bilhão"
 
 
 Humanization of floating point numbers:
@@ -140,33 +118,56 @@ Humanization of floating point numbers:
 .. code-block:: python
 
    humanizer_portugues.fractional(1/3)
-   '1/3'
+   "1/3"
 
    humanizer_portugues.fractional(1.5)
-   '1 1/2'
+   "1 1/2"
 
    humanizer_portugues.fractional(0.3)
-   '3/10'
+   "3/10"
 
    humanizer_portugues.fractional(0.333)
-   '333/1000'
+   "333/1000"
 
    humanizer_portugues.fractional(1)
-   '1'
+   "1"
 
 
-Humanization of lists:
+Humanization of dates and time:
 
 .. code-block:: python
 
-   humanizer_portugues.natural_list(['Cláudio', 'Maria'], ',')
-   'Cláudio, Maria'
+   import datetime
 
-   humanizer_portugues.natural_list(['Cláudio', 'Maria'], ',', 'e')
-   'Cláudio e Maria'
+   humanizer_portugues.natural_clock(datetime.time(0, 30, 0))
+   "zero hora e trinta minutos"
 
-   humanizer_portugues.natural_list(['Cláudio', 'Maria', 'José'], ';', 'ou')
-   'Cláudio; Maria ou José'
+   humanizer_portugues.natural_clock(datetime.time(0, 30, 0), formal=False)
+   "meia noite e meia"
+
+   humanizer_portugues.natural_date(datetime.date(2007, 6, 5))
+   "5 de junho de 2007"
+
+   humanizer_portugues.natural_day(datetime.datetime.now())
+   "hoje"
+
+   humanizer_portugues.natural_day(datetime.datetime.now() - datetime.timedelta(days=1))
+   "ontem"
+
+   humanizer_portugues.natural_day(datetime.date(2007, 6, 5))
+   "5 de junho"
+
+   humanizer_portugues.natural_delta(datetime.timedelta(seconds=1001))
+   "16 minutos"
+
+   humanizer_portugues.natural_period(datetime.time(5, 30, 0).hour)
+   "manhã"
+
+   humanizer_portugues.natural_time(datetime.datetime.now() - datetime.timedelta(seconds=1))
+   "há um segundo"
+
+   humanizer_portugues.natural_time(datetime.datetime.now() - datetime.timedelta(seconds=3600))
+   "há uma hora"
 
 
 Contributing

--- a/src/humanizer_portugues/__init__.py
+++ b/src/humanizer_portugues/__init__.py
@@ -1,12 +1,15 @@
 """Humanizer portugues."""
 from humanizer_portugues.filesize import natural_size
 from humanizer_portugues.list import natural_list
+from humanizer_portugues.number import ap_number
 from humanizer_portugues.number import fractional
 from humanizer_portugues.number import int_comma
 from humanizer_portugues.number import int_word
 from humanizer_portugues.number import ordinal
+from humanizer_portugues.time import natural_clock
 from humanizer_portugues.time import natural_date
 from humanizer_portugues.time import natural_day
+from humanizer_portugues.time import natural_delta
 from humanizer_portugues.time import natural_period
 from humanizer_portugues.time import natural_time
 from humanizer_portugues.time import natural_year
@@ -16,6 +19,7 @@ __all__ = [
     "fractional",
     "int_comma",
     "int_word",
+    "natural_clock",
     "natural_date",
     "natural_day",
     "natural_delta",

--- a/src/humanizer_portugues/time.py
+++ b/src/humanizer_portugues/time.py
@@ -168,7 +168,7 @@ def _informal_time(value: datetime.time, hour: int) -> str:
 
 
 def natural_clock(value: Any, formal: bool = True) -> Any:
-    """Returns human-readable time.
+    """Return human-readable time.
 
     Compares time values to present time returns representing readable of time
     with the given day period.
@@ -205,7 +205,7 @@ def natural_clock(value: Any, formal: bool = True) -> Any:
 
 
 def abs_timedelta(delta: datetime.timedelta) -> datetime.timedelta:
-    """Returns an "absolute" value for a timedelta.
+    """Return an "absolute" value for a timedelta.
 
     Args:
         delta (datetime.timedelta): relative timedelta.
@@ -220,7 +220,7 @@ def abs_timedelta(delta: datetime.timedelta) -> datetime.timedelta:
 
 
 def date_and_delta(value: Any) -> Tuple[Any, Any]:
-    """Returns date and timedelta.
+    """Return date and timedelta.
 
     Turn a value into a date and a timedelta which represents how long ago
     it was. If that's not possible, return (None, value).
@@ -297,7 +297,7 @@ def more_than_one_year(years: int) -> str:
 
 
 def natural_delta(value: Any, use_months: bool = True) -> Any:
-    """Returns human-readable time difference.
+    """Return human-readable time difference.
 
     Given a timedelta or a number of seconds, return a natural
     representation of the amount of time elapsed. This is similar to
@@ -332,7 +332,7 @@ def natural_delta(value: Any, use_months: bool = True) -> Any:
 
 
 def natural_time(value: Any, future: bool = False, use_months: bool = True) -> Any:
-    """Returns human-readable time.
+    """Return human-readable time.
 
     Given a datetime or a number of seconds, return a natural representation
     of that time in a resolution that makes sense. This is more or less
@@ -367,7 +367,7 @@ def natural_time(value: Any, future: bool = False, use_months: bool = True) -> A
 
 
 def natural_day(value: Any, has_year: bool = False) -> Any:
-    """Returns human-readable day.
+    """Return human-readable day.
 
     For date values that are tomorrow, today or yesterday compared to
     present day returns representing string. Otherwise, returns a string
@@ -400,7 +400,7 @@ def natural_day(value: Any, has_year: bool = False) -> Any:
 
 
 def natural_year(value: Any) -> Any:
-    """Returns human-readable year.
+    """Return human-readable year.
 
     For date values that are last year, this year or next year compared to
     present year returns representing string. Otherwise, returns a string
@@ -428,7 +428,7 @@ def natural_year(value: Any) -> Any:
 
 
 def natural_date(value: Any) -> Any:
-    """Returns human-readable date.
+    """Return human-readable date.
 
     Like natural_day, but will append a year for dates that are a year
     ago or more.

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,0 +1,74 @@
+"""__init__ tests."""
+import datetime
+
+import humanizer_portugues
+
+
+def test_natural_size() -> None:
+    """Call of natural_size from humanizer_portugues."""
+    assert humanizer_portugues.natural_size(1000000) == "1.0 MB"
+
+
+def test_natural_list() -> None:
+    """Call of natural_list from humanizer_portugues."""
+    assert (
+        humanizer_portugues.natural_list(["Cláudio", "Maria"], ",") == "Cláudio, Maria"
+    )
+
+
+def test_ap_number() -> None:
+    """Call of ap_number from humanizer_portugues."""
+    assert humanizer_portugues.ap_number(4) == "quatro"
+
+
+def test_int_comma() -> None:
+    """Call of int_comma from humanizer_portugues."""
+    assert humanizer_portugues.int_comma(12345) == "12,345"
+
+
+def test_int_word() -> None:
+    """Call of int_word from humanizer_portugues."""
+    assert humanizer_portugues.int_word(123455913) == "123.5 milhão"
+
+
+def test_fractional() -> None:
+    """Call of fractional from humanizer_portugues."""
+    assert humanizer_portugues.fractional(1 / 3) == "1/3"
+
+
+def test_natural_clock() -> None:
+    """Call of natural_clock from humanizer_portugues."""
+    date = datetime.time(0, 30, 0)
+    assert humanizer_portugues.natural_clock(date) == "zero hora e trinta minutos"
+
+
+def test_natural_date() -> None:
+    """Call of natural_date from humanizer_portugues."""
+    date = datetime.date(2007, 6, 5)
+    assert humanizer_portugues.natural_date(date) == "5 de junho de 2007"
+
+
+def test_natural_day() -> None:
+    """Call of natural_day from humanizer_portugues."""
+    assert humanizer_portugues.natural_day(datetime.datetime.now()) == "hoje"
+
+
+def test_natural_delta() -> None:
+    """Call of natural_delta from humanizer_portugues."""
+    delta = datetime.timedelta(seconds=1001)
+    assert humanizer_portugues.natural_delta(delta) == "16 minutos"
+
+
+def test_natural_period() -> None:
+    """Call of natural_period from humanizer_portugues."""
+    assert humanizer_portugues.natural_period(datetime.time(5, 30, 0).hour) == "manhã"
+
+
+def test_natural_time() -> None:
+    """Call of natural_time from humanizer_portugues."""
+    assert (
+        humanizer_portugues.natural_time(
+            datetime.datetime.now() - datetime.timedelta(seconds=1)
+        )
+        == "há um segundo"
+    )


### PR DESCRIPTION
- Update README to sort methods and modules in the same order as __init__
- Update init to add missing functions (ap_number, natural_clock, natural_delta)
- Add tests with the first example of each method in README calling from __init__

Closes #160 